### PR TITLE
Remove completed TODOs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ atm. only [Snyk Code](https://docs.snyk.io/products/snyk-code) is integrated
 
 and [Snyk Infrastructure as Code](https://docs.snyk.io/products/snyk-infrastructure-as-code) only for YAML files
 
-## @ToDo
-- [Snyk Infrastructure as Code](https://docs.snyk.io/products/snyk-infrastructure-as-code)
-- [Snyk Container](https://docs.snyk.io/products/snyk-container)
-- [Snyk Open Source](https://docs.snyk.io/products/snyk-open-source)
 
 ## Requirements
 [Getting started with Snyk](https://docs.snyk.io/getting-started)


### PR DESCRIPTION
The @ToDo section in README.md listed Snyk Infrastructure as Code, Snyk Container, and Snyk Open Source as pending tasks.

These features have been implemented in your codebase, as evidenced by the presence of corresponding job functions (startIaCJob, startContainerJob, startOpenSourceJob) in `lua/maorun/snyk/jobs.lua`, diagnostic functions (performIaC, performContainer, performOpenSource) in `lua/maorun/snyk/diagnostics.lua`, and their respective autocommands in `lua/maorun/snyk/autocmds.lua`.

This commit removes the now obsolete @ToDo section from the README.md file.